### PR TITLE
fix: add checkout step to workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -14,6 +14,8 @@ jobs:
       pull-requests: write  # required to create pull requests
       contents: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Update Lean project
         uses:  oliver-butterley/lean-update-action@v1-alpha.3
         with:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update_lean:


### PR DESCRIPTION
The updated draft version of update-lean-action requires the workflow which uses it to have a checkout step prior to using the action. 

Why it was changed like this:

This fits the standard pattern for actions and can be useful in some applications when the workflows does something to the project prior to using the action.

Of course update-lean-action should have a more professional method of recording and communicating the change log, particularly breaking changes like this. However I never have enough time to do most the things I want and thought such could wait for a beta version of the action.... 

resolves #oliver-butterley/lean-update-action/#11 